### PR TITLE
Added file png extension for ScreenShot class

### DIFF
--- a/app/src/androidTest/java/com/amazonaws/devicefarm/android/referenceapp/Util/ScreenShot.java
+++ b/app/src/androidTest/java/com/amazonaws/devicefarm/android/referenceapp/Util/ScreenShot.java
@@ -40,7 +40,7 @@ public class ScreenShot {
 
     public static void take(Activity activity){
 
-        final String path = Environment.getExternalStorageDirectory().getAbsolutePath() + DEVICE_FARM_ESPRESSO_SCREEN_DIRECTORY + UUID.randomUUID().toString();;
+        final String path = Environment.getExternalStorageDirectory().getAbsolutePath() + DEVICE_FARM_ESPRESSO_SCREEN_DIRECTORY + UUID.randomUUID().toString() + ".png";;
         Log.i(TAG, "Saving to path: " +  path);
 
         View phoneView = activity.getWindow().getDecorView().getRootView();


### PR DESCRIPTION
ADF requires files to be saved as PNG or JPEG I believe. For some Android configurations the existing code implementation works while others it requires an extension in code.