### PR TITLE
Upgrade project to use gradle 3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,21 +36,23 @@ repositories {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.jakewharton:butterknife:6.1.0'
-    compile 'com.google.code.gson:gson:2.3.1'
-    compile 'com.android.support:cardview-v7:21.0.3'
-    compile 'com.android.support:appcompat-v7:22.2.1'
-    compile 'com.android.support:recyclerview-v7:22.2.0'
-    compile 'com.android.support:support-v4:22.2.1'
-    compile 'com.google.android.gms:play-services-location:7.5.0'
-    compile 'com.squareup.picasso:picasso:2.5.2'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.jakewharton:butterknife:8.1.0'
+    implementation 'com.google.code.gson:gson:2.8.0'
+    implementation 'com.android.support:cardview-v7:22.2.1'
+    implementation 'com.android.support:appcompat-v7:22.2.1'
+    implementation 'com.android.support:recyclerview-v7:22.2.1'
+    implementation 'com.android.support:support-v4:22.2.1'
+    implementation 'com.google.android.gms:play-services-location:10.0.0'
+    implementation 'com.squareup.picasso:picasso:2.5.2'
 
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2'
-    androidTestCompile 'com.android.support.test.espresso:espresso-web:2.2'
-    androidTestCompile 'com.android.support.test:runner:0.3'
-    androidTestCompile 'com.android.support.test:rules:0.3'
-    androidTestCompile ('com.android.support.test.espresso:espresso-contrib:2.2'){
+    annotationProcessor 'com.jakewharton:butterknife-compiler:8.1.0'
+
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:2.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-web:2.2'
+    androidTestImplementation 'com.android.support.test:runner:0.3'
+    androidTestImplementation 'com.android.support.test:rules:0.3'
+    androidTestImplementation ('com.android.support.test.espresso:espresso-contrib:2.2'){
         exclude group: 'com.android.support', module: 'appcompat'
         exclude group: 'com.android.support', module: 'support-v4'
         exclude module: 'recyclerview-v7'

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Activities/BackNavigationActivity.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Activities/BackNavigationActivity.java
@@ -25,8 +25,8 @@ import android.widget.TextView;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 import butterknife.OnClick;
 
 /**
@@ -41,20 +41,20 @@ import butterknife.OnClick;
 public class BackNavigationActivity extends AppCompatActivity {
     private int PeerCount;
 
-    @InjectView(R.id.toolbar)
+    @BindView(R.id.toolbar)
     Toolbar toolbar;
 
-    @InjectView(R.id.back_navigation_counter)
+    @BindView(R.id.back_navigation_counter)
     TextView counter;
 
-    @InjectView(R.id.toolbar_title)
+    @BindView(R.id.toolbar_title)
     TextView toolbarTitle;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.back_navigation);
-        ButterKnife.inject(this);
+        ButterKnife.bind(this);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setDisplayShowTitleEnabled(false);

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Activities/MainActivity.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Activities/MainActivity.java
@@ -37,8 +37,8 @@ import com.amazonaws.devicefarm.android.referenceapp.Util.JsonParser;
 import java.util.ArrayList;
 import java.util.List;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * <h1>Main acitivity</h1>
@@ -49,13 +49,13 @@ import butterknife.InjectView;
  * </p>
  */
 public class MainActivity extends AppCompatActivity implements DrawerAdapter.OnItemClickListener{
-    @InjectView(R.id.toolbar)
+    @BindView(R.id.toolbar)
     Toolbar toolbar;
 
-    @InjectView(R.id.toolbar_title)
+    @BindView(R.id.toolbar_title)
     TextView toolbarTitle;
 
-    @InjectView(R.id.drawer_layout)
+    @BindView(R.id.drawer_layout)
     DrawerLayout drawerLayout;
 
     /**
@@ -66,7 +66,7 @@ public class MainActivity extends AppCompatActivity implements DrawerAdapter.OnI
     public void onCreate(Bundle savedInstance) {
         super.onCreate(savedInstance);
         setContentView(R.layout.activity_main);
-        ButterKnife.inject(this);
+        ButterKnife.bind(this);
         generateDataModel();
         setUpToolBar();
         setUpNavigationDrawer();

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Activities/UpNavigationActivity.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Activities/UpNavigationActivity.java
@@ -25,8 +25,8 @@ import android.widget.TextView;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 import butterknife.OnClick;
 
 /**
@@ -36,17 +36,17 @@ import butterknife.OnClick;
  * </p>
  */
 public class UpNavigationActivity extends AppCompatActivity {
-    @InjectView(R.id.toolbar)
+    @BindView(R.id.toolbar)
     Toolbar toolbar;
 
-    @InjectView(R.id.toolbar_title)
+    @BindView(R.id.toolbar_title)
     TextView toolbarTitle;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.up_navigation);
-        ButterKnife.inject(this);
+        ButterKnife.bind(this);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setDisplayShowTitleEnabled(false);

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Activities/UpNavigationContent.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Activities/UpNavigationContent.java
@@ -27,8 +27,8 @@ import android.widget.TextView;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * <h1>Up Navigation Content Activity</h1>
@@ -37,23 +37,23 @@ import butterknife.InjectView;
  * </p>
  */
 public class UpNavigationContent extends AppCompatActivity{
-    @InjectView(R.id.toolbar)
+    @BindView(R.id.toolbar)
     Toolbar toolbar;
 
-    @InjectView(R.id.nested_up_button)
+    @BindView(R.id.nested_up_button)
     Button nextButton;
 
-    @InjectView(R.id.toolbar_title)
+    @BindView(R.id.toolbar_title)
     TextView toolbarTitle;
 
-    @InjectView(R.id.up_navigation_content_text)
+    @BindView(R.id.up_navigation_content_text)
     TextView content_text;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.up_navigation);
-        ButterKnife.inject(this);
+        ButterKnife.bind(this);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setDisplayShowTitleEnabled(false);

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Adapters/DrawerAdapter.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Adapters/DrawerAdapter.java
@@ -29,8 +29,8 @@ import com.amazonaws.devicefarm.android.referenceapp.R;
 
 import java.util.List;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * <h1>Navigation Drawer Adapter</h1>
@@ -56,13 +56,13 @@ public class DrawerAdapter extends RecyclerView.Adapter<DrawerAdapter.ViewHolder
     public static class ViewHolder extends RecyclerView.ViewHolder {
         protected int viewType;
 
-        @InjectView(R.id.drawer_row_icon) ImageView rowImage;
-        @InjectView(R.id.drawer_row_title) TextView rowTitle;
+        @BindView(R.id.drawer_row_icon) ImageView rowImage;
+        @BindView(R.id.drawer_row_title) TextView rowTitle;
 
         public ViewHolder(View itemView, int viewType) {
             super(itemView);
             this.viewType = viewType;
-            ButterKnife.inject(this, itemView);
+            ButterKnife.bind(this, itemView);
         }
     }
 

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/FixturesFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/FixturesFragment.java
@@ -41,8 +41,8 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.location.LocationServices;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * A fragment to detect the radio statuses within the Android app
@@ -53,17 +53,17 @@ public class FixturesFragment extends Fragment implements
 
     private static final String TAG = "fixtures-fragment";
 
-    @InjectView(R.id.longitude)
+    @BindView(R.id.longitude)
     TextView longitude;
-    @InjectView(R.id.lat)
+    @BindView(R.id.lat)
     TextView lat;
-    @InjectView(R.id.wifi)
+    @BindView(R.id.wifi)
     TextView wifi;
-    @InjectView(R.id.bluetooth)
+    @BindView(R.id.bluetooth)
     TextView bluetooth;
-    @InjectView(R.id.gps)
+    @BindView(R.id.gps)
     TextView gps;
-    @InjectView(R.id.nfc)
+    @BindView(R.id.nfc)
     TextView nfc;
 
     private GoogleApiClient googleApiClient;
@@ -72,7 +72,7 @@ public class FixturesFragment extends Fragment implements
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, final Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fixtures_layout, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         buildGoogleApiClient();
 
         //Registering events to detect radio changes

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/LocalWebView.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/LocalWebView.java
@@ -26,22 +26,22 @@ import android.widget.EditText;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 
 public class LocalWebView extends Fragment {
 
-    @InjectView(R.id.website_input)
+    @BindView(R.id.website_input)
     EditText websiteInput;
 
-    @InjectView(R.id.webView_browser)
+    @BindView(R.id.webView_browser)
     WebView webView;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.web_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         websiteInput.setVisibility(View.GONE);
         setUpWebView();
         return view;

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/LoginFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/LoginFragment.java
@@ -27,8 +27,8 @@ import android.widget.TextView;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 import butterknife.OnClick;
 
 /**
@@ -44,32 +44,32 @@ public class LoginFragment extends Fragment {
     private String ALT_BUTTON_SUCCESS_TITLE;
     private InputMethodManager imm;
 
-    @InjectView(R.id.login_main_view)
+    @BindView(R.id.login_main_view)
     View mainView;
 
-    @InjectView(R.id.login_alt_view)
+    @BindView(R.id.login_alt_view)
     View altView;
 
-    @InjectView(R.id.username_text_input)
+    @BindView(R.id.username_text_input)
     EditText usernameInput;
 
-    @InjectView(R.id.password_text_input)
+    @BindView(R.id.password_text_input)
     EditText passwordInput;
 
-    @InjectView(R.id.login_button)
+    @BindView(R.id.login_button)
     Button loginButton;
 
-    @InjectView(R.id.login_alt_message_textView)
+    @BindView(R.id.login_alt_message_textView)
     TextView altText;
 
-    @InjectView(R.id.alt_button)
+    @BindView(R.id.alt_button)
     Button altButton;
 
     public LoginFragment(){}
 
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view =  inflater.inflate(R.layout.fragment_login, container, false);
-        ButterKnife.inject(this,view);
+        ButterKnife.bind(this,view);
 
         USERNAME = getString(R.string.login_username);
         PASSWORD = getString(R.string.login_password);

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/NavigationDrawerFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/NavigationDrawerFragment.java
@@ -34,16 +34,16 @@ import com.amazonaws.devicefarm.android.referenceapp.R;
 
 import java.util.List;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
-import static android.content.Context.*;
+import static android.content.Context.INPUT_METHOD_SERVICE;
 
 /**
  * Fragment for the the navigation drawer
  */
 public class NavigationDrawerFragment extends Fragment {
-    @InjectView(R.id.drawerList)
+    @BindView(R.id.drawerList)
     RecyclerView recycleView;
 
     private DrawerAdapter drawerAdapter;
@@ -89,7 +89,7 @@ public class NavigationDrawerFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View layout = inflater.inflate(R.layout.fragment_navigation_drawer, container, false);
-        ButterKnife.inject(this, layout);
+        ButterKnife.bind(this, layout);
         return layout;
     }
 }

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/NestedFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/NestedFragment.java
@@ -36,7 +36,7 @@ public class NestedFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.nested_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         return view;
     }
 

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/NotificationsFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/NotificationsFragment.java
@@ -37,7 +37,7 @@ public class NotificationsFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.notifications_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         return view;
     }
 

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/TabFragmentContainer.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/TabFragmentContainer.java
@@ -28,8 +28,8 @@ import com.amazonaws.devicefarm.android.referenceapp.R;
 
 import java.util.List;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * A fragment container for fragments with tabs
@@ -37,7 +37,7 @@ import butterknife.InjectView;
  */
 public class TabFragmentContainer extends Fragment {
 
-    @InjectView(R.id.view_pager1)
+    @BindView(R.id.view_pager1)
     ViewPager pager;
 
     public TabFragmentContainer() {}
@@ -45,7 +45,7 @@ public class TabFragmentContainer extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {//TODO SINGLETON or single instance?
         View view =  inflater.inflate(R.layout.tab_fragment_container, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         return view;
     }
 

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_CheckBoxFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_CheckBoxFragment.java
@@ -27,23 +27,23 @@ import android.widget.TextView;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * A fragment demonstrating a checkbox input
  */
 public class Input_CheckBoxFragment extends Fragment implements CheckBox.OnCheckedChangeListener{
-    @InjectView(R.id.input_checkbox_status)
+    @BindView(R.id.input_checkbox_status)
     TextView checkbox_display;
 
-    @InjectView(R.id.input_checkbox)
+    @BindView(R.id.input_checkbox)
     CheckBox checkBox;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.input_checkbox_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         changeDisplay();
         checkBox.setOnCheckedChangeListener(this);
         return view;

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_DatePickerFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_DatePickerFragment.java
@@ -25,23 +25,23 @@ import android.widget.TextView;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * Fragment which represents datepicker input
  */
 public class Input_DatePickerFragment extends Fragment implements DatePicker.OnDateChangedListener{
-    @InjectView(R.id.input_datepicker)
+    @BindView(R.id.input_datepicker)
     DatePicker datePicker;
 
-    @InjectView(R.id.input_date_display)
+    @BindView(R.id.input_date_display)
     TextView timeDisplay;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.input_datepicker_fragment, container, false);
-        ButterKnife.inject(this,view);
+        ButterKnife.bind(this,view);
         datePicker.init(1994,6,5,this);
         changeDisplay(datePicker.getYear(),datePicker.getMonth(),datePicker.getDayOfMonth());
         return view;

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_GestureFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_GestureFragment.java
@@ -28,23 +28,23 @@ import android.widget.TextView;
 import com.amazonaws.devicefarm.android.referenceapp.Adapters.GestureListener;
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * Fragment demonstrating a touch inputs
  */
 public class Input_GestureFragment extends Fragment{
-    @InjectView(R.id.input_gesture_action_pad)
+    @BindView(R.id.input_gesture_action_pad)
     FrameLayout actionPad;
 
-    @InjectView(R.id.input_gesture_content)
+    @BindView(R.id.input_gesture_content)
     TextView gestureContent;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.input_gesture_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         actionPad.setClickable(true);
         actionPad.setFocusable(true);
 

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_RadioButtonFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_RadioButtonFragment.java
@@ -26,24 +26,24 @@ import android.widget.TextView;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * A fragment demonstrating radio button input
  */
 public class Input_RadioButtonFragment extends Fragment implements RadioGroup.OnCheckedChangeListener{
-    @InjectView(R.id.radio_button_group)
+    @BindView(R.id.radio_button_group)
     RadioGroup radioGroup;
 
-    @InjectView(R.id.input_radio_button_display)
+    @BindView(R.id.input_radio_button_display)
     TextView radioButtonDisplay;
 
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.input_radio_button_fragment, container, false);
-        ButterKnife.inject(this,view);
+        ButterKnife.bind(this,view);
         radioGroup.setOnCheckedChangeListener(this);
         radioButtonDisplay.setText(getString(R.string.radio_button_1));
         return view;

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_RefreshButtonFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_RefreshButtonFragment.java
@@ -30,24 +30,24 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * A fragment representing a refresh input
  */
 public class Input_RefreshButtonFragment extends android.support.v4.app.Fragment implements
         SwipeRefreshLayout.OnRefreshListener{
-    @InjectView(R.id.input_refresh)
+    @BindView(R.id.input_refresh)
     SwipeRefreshLayout swipeRefreshLayout;
 
-    @InjectView(R.id.input_refresh_display)
+    @BindView(R.id.input_refresh_display)
     TextView textView;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.input_refresh_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         swipeRefreshLayout.setOnRefreshListener(this);
         return view;
     }

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_SpinnerFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_SpinnerFragment.java
@@ -27,23 +27,23 @@ import android.widget.TextView;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * A fragment representing a spinner input
  */
 public class Input_SpinnerFragment extends Fragment implements Spinner.OnItemSelectedListener{
-    @InjectView(R.id.input_spinner)
+    @BindView(R.id.input_spinner)
     Spinner spinner;
 
-    @InjectView(R.id.input_spinner_message)
+    @BindView(R.id.input_spinner_message)
     TextView textView;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.input_spinner_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         spinnerAdapter();
         spinner.setOnItemSelectedListener(this);
         return view;

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_SubmitButtonFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_SubmitButtonFragment.java
@@ -36,7 +36,7 @@ public class Input_SubmitButtonFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.input_submit_button_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         return view;
     }
 

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_TimePickerFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_TimePickerFragment.java
@@ -25,23 +25,23 @@ import android.widget.TimePicker;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * A fragment demonstrating a time picker input
  */
 public class Input_TimePickerFragment extends Fragment  implements TimePicker.OnTimeChangedListener{
-    @InjectView(R.id.input_timepicker)
+    @BindView(R.id.input_timepicker)
     TimePicker timePicker;
 
-    @InjectView(R.id.input_time_display)
+    @BindView(R.id.input_time_display)
     TextView timeDisplay;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.input_timepicker_fragment, container, false);
-        ButterKnife.inject(this,view);
+        ButterKnife.bind(this,view);
         timePicker.setOnTimeChangedListener(this);
         timeDisplay.setText(getString(R.string.time_picker_default_display));
         return view;

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_Toggle_ButtonFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Inputs/Input_Toggle_ButtonFragment.java
@@ -24,21 +24,21 @@ import android.view.ViewGroup;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 import butterknife.OnClick;
 
 /**
  * A fragment demonstrating the toggle button
  */
 public class Input_Toggle_ButtonFragment extends Fragment {
-    @InjectView(R.id.input_switch_display)
+    @BindView(R.id.input_switch_display)
     View switchDisplay;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.input_toggle_button_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         switchDisplay.setBackgroundColor(getResources().getColor(R.color.custom_grey));
         switchDisplay.setContentDescription("OFF");
         return view;

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Native/Native_CameraFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Native/Native_CameraFragment.java
@@ -29,8 +29,8 @@ import android.view.ViewGroup;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * A fragment that demos a camera preview
@@ -40,7 +40,7 @@ public class Native_CameraFragment extends Fragment implements SurfaceHolder.Cal
 
     Camera camera;
 
-    @InjectView(R.id.camera_surface_view)
+    @BindView(R.id.camera_surface_view)
     SurfaceView surfaceView;
 
     private SurfaceHolder surfaceHolder;
@@ -48,7 +48,7 @@ public class Native_CameraFragment extends Fragment implements SurfaceHolder.Cal
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.native_camera_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         surfaceHolder = surfaceView.getHolder();
         surfaceHolder.addCallback(this);
         surfaceHolder.setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Native/Native_ImageGalleryFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Native/Native_ImageGalleryFragment.java
@@ -25,20 +25,20 @@ import android.widget.GridView;
 import com.amazonaws.devicefarm.android.referenceapp.Adapters.ImageGalleryAdapter;
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * A fragment that demonstrates a root image gallery view
  */
 public class Native_ImageGalleryFragment extends Fragment {
-    @InjectView(R.id.native_image_grid_view)
+    @BindView(R.id.native_image_grid_view)
     GridView imageGalley;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, final Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.native_imagegallery_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         imageGalley.setAdapter(new ImageGalleryAdapter(getActivity()));
         return view;
     }

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Native/Native_MediaPlayer.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/Tabs/Native/Native_MediaPlayer.java
@@ -27,8 +27,8 @@ import android.widget.VideoView;
 
 import com.amazonaws.devicefarm.android.referenceapp.R;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 
 /**
  * A fragment that demonstrates playing a media file
@@ -36,7 +36,7 @@ import butterknife.InjectView;
 public class Native_MediaPlayer extends Fragment{
     private String movieUri;
 
-    @InjectView(R.id.native_video_player)
+    @BindView(R.id.native_video_player)
     VideoView videoView;
 
     MediaPlayer player;
@@ -44,7 +44,7 @@ public class Native_MediaPlayer extends Fragment{
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.native_mediaplayer_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         movieUri = "android.resource://" + getActivity().getPackageName() + "/" + R.raw.movie;
         new BackgroundVideoTask().execute(movieUri);
         return view;

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/WebViewFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/WebViewFragment.java
@@ -35,8 +35,8 @@ import com.amazonaws.devicefarm.android.referenceapp.Util.Util;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.InjectView;
 import butterknife.OnEditorAction;
 
 /**
@@ -44,10 +44,10 @@ import butterknife.OnEditorAction;
  */
 public class WebViewFragment extends Fragment {
 
-    @InjectView(R.id.website_input)
+    @BindView(R.id.website_input)
     EditText websiteInput;
 
-    @InjectView(R.id.webView_browser)
+    @BindView(R.id.webView_browser)
     WebView webView;
 
     private boolean isError;
@@ -57,7 +57,7 @@ public class WebViewFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.web_fragment,container,false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         isError = false;
         //Needed in order to run within appium
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)

--- a/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/crashFragment.java
+++ b/app/src/main/java/com/amazonaws/devicefarm/android/referenceapp/Fragments/crashFragment.java
@@ -36,7 +36,7 @@ public class crashFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.crash_fragment, container, false);
-        ButterKnife.inject(this, view);
+        ButterKnife.bind(this, view);
         return view;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,6 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }


### PR DESCRIPTION
This PR is to use gradle 3.0 in our sample app. 

Upgrading to gradle 3 required the following changes: 

- `compile` keyword has changed to `implementation` in `build.gradle`
- `androidTestCompile` has changed to `androidTestImplementation` in `build.gradle`
- The butterknife library required an upgrade to version 8.0
- The butterknife annotations and API had changed names from `inject` to `bind`